### PR TITLE
fix(build): fixes style overrides in static build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "storybook": "start-storybook -s ./static -p 6006",
     "sb": "yarn run storybook",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -s ./static",
     "bootstrap": "lerna bootstrap",
     "version": "lerna version --conventional-commits",
     "publish": "lerna publish from-package",


### PR DESCRIPTION
There was an issue with the static build of Storybook not getting the custom styles that are defined in the `static/style/storybook.css` file, because those static assets weren't being passed to the build command. This fixes that issue.

This is what it looked like before this fix:
![image](https://user-images.githubusercontent.com/173844/101219573-3affe880-3652-11eb-9510-3c307a6a7c32.png)

And this is what it looks like _with_ this fix:
![image](https://user-images.githubusercontent.com/173844/101219635-48b56e00-3652-11eb-858c-d586802d44d4.png)

![](https://media.tenor.com/images/e02b895afafc7a272b612d2f8583338f/tenor.gif)