### PR TITLE
fix(ch55): updated package configs to allow for publishing publicly

### DIFF
--- a/components/external-link/package.json
+++ b/components/external-link/package.json
@@ -9,6 +9,9 @@
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "react": "~17.0.0"
   },

--- a/components/icons/package.json
+++ b/components/icons/package.json
@@ -9,6 +9,9 @@
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "react": "~17.0.0"
   },

--- a/components/list/package.json
+++ b/components/list/package.json
@@ -9,6 +9,9 @@
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "react": "~17.0.0"
   },

--- a/components/logos/package.json
+++ b/components/logos/package.json
@@ -9,6 +9,9 @@
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@aoeu/logo-svgs": "^0.0.1"
   },

--- a/components/notification/package.json
+++ b/components/notification/package.json
@@ -9,6 +9,9 @@
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@aoeu/util": "^0.0.1",
     "react-toastify": "^6.1.0"

--- a/guides/components-overview.stories.mdx
+++ b/guides/components-overview.stories.mdx
@@ -48,6 +48,9 @@ Packages in a monorepo that are intended to be published and consumed by depende
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@aoeu/util": "^0.3.0"
   },
@@ -103,6 +106,10 @@ If/when necessary and public contributions get submitted to the repository, a `c
 #### `license`
 
 In the vast majority of cases, we wish to share our packages with the Open Source community, and as such the `license` attribute should nearly always be set to `MIT`, and the `LICENSE` file in the package folder should match this. In select cases where a package contains artifacts that have intellectual property rights owned by The Art of Education University (i.e. our `@aoeu/logo-svgs` and `@aoeu/logos` packages), a different, more IP specific value can and should be specified.
+
+#### `publishConfig` => `access`
+
+It's important to include the `publishConfig` attribute, with a child `access` attribute with a value set to `public`, as this instructs the npm CLI to allow us to publish our components and packages scoped to the `@aoeu` org on the npm registry, and allow them to be publicly accessible. Most commonly scoped packages published to the npm registry are private, which requires paying npm for private package hosting. This attribute allows us to publish to a scope, but not have the packages be private, which is what we want.
 
 #### `dependencies` and `devDependencies`
 

--- a/packages/logo-svgs/package.json
+++ b/packages/logo-svgs/package.json
@@ -7,5 +7,8 @@
     "**/*.svg"
   ],
   "author": "The Art of Education University",
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/sass/package.json
+++ b/packages/sass/package.json
@@ -8,6 +8,9 @@
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "sass": "^1.27.1"
   }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -9,6 +9,9 @@
   ],
   "author": "The Art of Education University",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prebuild": "rm -rf ./dist",
     "build": "webpack --config ../../webpack.config.js"


### PR DESCRIPTION
This PR supports [CH55](https://app.clubhouse.io/aoeu-se/story/55/setup-ui-common-as-a-monorepo-with-lerna-and-yarn-workspaces), and configures each individual component and package to support publishing to the npm registry with public access.