### PR TITLE
build(ch23): fixed webpack config to support node.js builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,8 @@ module.exports = {
   output: {
     filename: "index.js",
     library: "aoeu-ui-common",
-    libraryTarget: "umd"
+    libraryTarget: "umd",
+    globalObject: "this"
   },
   resolve: {
     extensions: [".js", ".jsx", ".json"],


### PR DESCRIPTION
[CH23](https://app.clubhouse.io/aoeu-se/story/23/deploy-to-github-pages) - OK, so, here's the story. Yesterday, I was working on getting the `engineering-docs` project updated to consume the packages we had published from `ui-common`, and everything was going well, until I merged in to the `main` branch, and the CD action ran which attempted to run `docusaurus build`, which blew up.

I started looking more closely at this, and discovered that I was able to reproduce the error locally, but the error stack was nothing but a bunch of output from webpack internals ... nothing in the call stack linked back to anything of ours or anything like that, which made it a bit difficult to try to figure out where the problem might be coming from. The build was generating an error when it was attempting to build the server side of the app. The client builds just fine, but the server wouldn't build. Webpack was throwing a compilation error, something about `self is not defined` or something like that.

So, I did some debugging by generating a totally fresh, clean install of docusaurus, and piece-by-piece, adding in the customizations that I had made to it, and was finally able to narrow down that it was the addition and use of the `@aoeu/external-link` component that was causing the problem. So from there it was pretty easy to see that there was something wrong with our webpack build for our components in `ui-common` and the format with which we were generating their compile output.

Ssooo I did some searching on the error, and immediately found [this issue](https://github.com/webpack/webpack/issues/6522) on the webpack GitHub repository. The discussion in that issue provided some insight into what the issue was, and one of the more recent comments in the discussion linked to [the documentation for the `output.globalObject` configuration property](https://webpack.js.org/configuration/output/#outputglobalobject), which literally reads:

> _When targeting a library, especially when libraryTarget is 'umd', this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'. Defaults to self for Web-like targets._

That is _exactly_ the situation we're in right now, and from what I can tell, this should hopefully fix the issue.